### PR TITLE
Upgrade to use serialport > 4 (linked to last serialport lib >= 7.0.1)

### DIFF
--- a/lib/xbee.js
+++ b/lib/xbee.js
@@ -18,7 +18,7 @@ util.inherits(XBee, EventEmitter);
 XBee.prototype.init = function () {
   var me = this;
 
-  if (me.serialConnection.isOpen()) {
+  if (me.serialConnection.isOpen) {
     me.emit('open' + me.config.id);
   } else {
     me.serialConnection.open(function (err) {
@@ -45,7 +45,7 @@ XBee.prototype._initSerial = function () {
   this.serialConnection = new SerialPort(this.config.serialPort, {
     autoOpen: false,
     lock: this.config.lock,
-    baudrate: this.config.baudRate,
+    baudRate: this.config.baudRate,
     dataBits: this.config.dataBits,
     stopBits: this.config.stopBits,
     parity: this.config.parity,
@@ -53,13 +53,17 @@ XBee.prototype._initSerial = function () {
     xon: this.config.xon,
     xoff: this.config.xoff,
     xany: this.config.xany,
-    bufferSize: this.config.bufferSize,
-    parser: this.xbeeAPI.rawParser(),
+    highWaterMark: this.config.bufferSize, // buffersSize
+    //parser: this.xbeeAPI.rawParser(),
     platformOptions: {
       vmin: this.config.vmin,
       vtime: this.config.vtime
     }
   });
+
+  me.serialConnection.pipe(me.xbeeAPI.parser);
+  me.xbeeAPI.builder.pipe(me.serialConnection);
+
   this.serialConnection.on('disconnect', function () {
     me.emit('disconnect' + me.config.id);
   });
@@ -73,7 +77,7 @@ XBee.prototype.close = function (cb) {
   me.removeAllListeners('sent' + me.config.id);
   me.removeAllListeners('error' + me.config.id);
   me.removeAllListeners('disconnect' + me.config.id);
-  if (me.serialConnection.isOpen()) {
+  if (me.serialConnection.isOpen) {
     me.serialConnection.close(cb);
   }
 };
@@ -82,7 +86,8 @@ XBee.prototype.listen = function () {
   var me = this;
   if (!me.isListening) {
     me.isListening = true;
-    me.xbeeAPI.on('frame_object', function (frame) {
+
+    me.xbeeAPI.parser.on('data', function (frame) {
       me.emit('data' + me.config.id, frame);
     }).on('error', function (err) {
       me.emit('error' + me.config.id, err);
@@ -92,11 +97,9 @@ XBee.prototype.listen = function () {
 
 XBee.prototype.transmit = function (data) {
   var me = this;
-  if (me.serialConnection.isOpen()) {
+  if (me.serialConnection.isOpen) {
     try {
-      me.serialConnection.write(
-        me.xbeeAPI.buildFrame(data)
-      );
+		me.xbeeAPI.builder.write(data);
       me.emit('sent' + me.config.id);
     } catch (error) {
       me.emit('error' + me.config.id, error);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-xbee",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Node-RED module for the Xbee radio modules",
   "repository": {
     "type": "git",
@@ -22,7 +22,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "serialport": "^4.0.7",
-    "xbee-api": "^0.5.2"
+    "serialport": "^7.1.0",
+    "xbee-api": "^0.6.0"
   }
 }


### PR DESCRIPTION
Hi, 
I needed to use nod-red-contrib-xbee. It did not work with lastest node-.js (LTS 10.13) and serialport lib (7). I upgraded it to work with these new release.
All the best.